### PR TITLE
feat: expose node_groups_defaults

### DIFF
--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -211,7 +211,7 @@ module "cluster" {
 
   # eks-managed node groups
   node_groups          = local.node_groups
-  node_groups_defaults = {}
+  node_groups_defaults = var.node_groups_defaults
 
   write_kubeconfig = false
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -253,3 +253,14 @@ variable "workers_group_defaults" {
   }
 }
 
+variable "node_groups_defaults" {
+  type = any
+  description = "Override default values for self-managed eks node pool."
+  default = {
+    create_launch_template               = true
+    metadata_http_endpoint               = "enabled"
+    metadata_http_tokens                 = "required"
+    metadata_http_put_response_hop_limit = 2 # As recommended by AWS https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#set-imdsv2-account-defaults
+  }
+}
+


### PR DESCRIPTION
### Summary 💡
This PR exposes the `node_groups_defaults` Terraform variable.

Relates: https://github.com/sighupio/distribution

### Description 📝
This was already done for nodes that are handled by the customer with the variable `workers_group_defaults`.

This allows us to set `metadata_http_put_response_hop_limit`, `metadata_http_tokens` and `metadata_http_endpoint`. We are also setting some sensible defaults to these values, in order to satisfy `alinux2023` requirements.

Furthermore, to allow ALB controller to correctly contact the IMDSv2 service, we need to set the hop limit to 2, otherwise the installation will fail.

### Breaking Changes 💔
None.

### Tests performed 🧪
Tested an installation with the module. SIGHUP Distribution's e2e tests with this branch resulted in a green execution. 

### Future work 🔧
Refactor this module. We're a little bit behind in terms of Terraform provider version.

